### PR TITLE
Fixed: golangci-lint out-format error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.32.2
-          args: --timeout=5m --out-format=colored-line-number -E asciicheck -E bodyclose -E dupl -E errorlint -E exportloopref -E funlen
-
+          args: --timeout=5m -E asciicheck -E bodyclose -E dupl -E errorlint -E exportloopref -E funlen


### PR DESCRIPTION
## Please describe the change you are making

I removed the out-format parameter because it causes errors with newer versions. 🤷‍♂️

```
Error: Failed to run: Error: please, don't change out-format for golangci-lint: it can be broken in a future, Error: please, don't change out-format for golangci-lint: it can be broken in a future
    at /home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:6831:19
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:6713:71
    at new Promise (<anonymous>)
    at module.exports.__awaiter (/home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:6709:12)
    at runLint (/home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:6816:12)
    at /home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:6885:57
    at Object.<anonymous> (/home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:42546:28)
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/golangci/golangci-lint-action/v2/dist/run/index.js:42349:71
```