### PR TITLE
Fixes #487: aarch64 support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
   - id: containerssh-auditlog-decoder
@@ -24,6 +25,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
   - id: containerssh-testauthconfigserver
@@ -36,6 +38,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds aarch64 build support as requested in #487

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).