### PR TITLE
Replace expire slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In a hurry? This one-minute video explains everything you need to know about Con
 
 ## Need help?
 
-[Join the Slack channel »](https://join.slack.com/t/containerssh/shared_invite/zt-w2ulatkm-hjGHk8OaxQCBX79XKJHAQQ)
+[Join the Slack channel of CNCF »](https://communityinviter.com/apps/cloud-native/cncf)
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In a hurry? This one-minute video explains everything you need to know about Con
 
 ## Need help?
 
-[Join the Slack channel of CNCF »](https://communityinviter.com/apps/cloud-native/cncf)
+[Join the #containerssh Slack channel on the CNCF Slack »](https://communityinviter.com/apps/cloud-native/cncf)
 
 ## Use cases
 


### PR DESCRIPTION
## Changes introduced with this PR

Replace the expired Slack channel link with CNCF community invite link, which will help in join CNCF slack channel
issue #565
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).