### PR TITLE
Modify the build process to generate a signed SLSA provenance to verify produced artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,41 +6,79 @@ on:
       - '*'
     tags:
       - '*'
+
 jobs:
-  build:
-    name: Build
+  snapshot:
+    name: Snapshot build
     runs-on: ubuntu-latest
+    if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout the repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: 1.18
+          go-version: 1.21
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Import signing key
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "${GPG_KEY}" | base64 -d | gpg --batch --import && echo "${GPG_KEY}" | base64 -d >/tmp/signing.gpg
-        env:
-          GPG_KEY: "${{ secrets.GPG_KEY }}"
+        uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c #v3
       - name: Run GoReleaser (snapshot)
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 #v5.0.0
         with:
           version: latest
-          args: build --snapshot --rm-dist
-      - name: Run GoReleaser (release)
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+          args: build --snapshot --clean
+      - name: Upload artifacts
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: build-results
           path: build
           if-no-files-found: error
+
+  release:
+    name: Release build
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
+        with:
+          go-version: 1.21
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c #v3
+      - name: Import GPG key
+        run: |
+          echo "${GPG_KEY}" | base64 -d | gpg --batch --import && echo "${GPG_KEY}" | base64 -d >/tmp/signing.gpg
+        env:
+          GPG_KEY: "${{ secrets.GPG_KEY }}"
+      - name: Run GoReleaser (release)
+        id: goreleaser-task
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 #v5.0.0
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate subject (checksum)
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.goreleaser-task.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [release]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      upload-assets: true
+      draft-release: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,24 +7,25 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout the repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: 1.18
+          go-version: 1.21
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c #v3
       - name: Update libcontainerssh
         run: |
           go get go.containerssh.io/libcontainerssh@main
           go mod tidy
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+      - name: Run GoReleaser (snapshot)
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 #v5.0.0
         with:
           version: latest
-          args: build --snapshot --rm-dist
-      - uses: actions/upload-artifact@v3
+          args: build --snapshot --clean
+      - name: Upload artifacts
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: build-results
           path: build

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,9 +92,9 @@ source:
   name_template: '{{ .ProjectName }}-{{ .Version }}-source'
 dist: build
 release:
-  #github:
-    #owner: containerssh
-    #name: containerssh
+  github:
+    owner: containerssh
+    name: containerssh
   prerelease: auto
   extra_files:
     - glob: LICENSE

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,9 +92,9 @@ source:
   name_template: '{{ .ProjectName }}-{{ .Version }}-source'
 dist: build
 release:
-  github:
-    owner: containerssh
-    name: containerssh
+  #github:
+    #owner: containerssh
+    #name: containerssh
   prerelease: auto
   extra_files:
     - glob: LICENSE

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,8 +85,8 @@ nfpms:
           group: root
           mode: 0755
 signs:
-  - id: sign-all
-    artifacts: all
+  - id: sign-checksums
+    artifacts: checksum
 source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{ .Version }}-source'

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ Study SSH attack patterns up close. Drop attackers safely into network-isolated 
 
 [🚀 Get started »](https://containerssh.io/quickstart/)
 
+## Verify provenance
+
+Each of the releases come with a SLSA provenance data file `multiple.intoto.jsonl`. This file can be used to verify the source and provenance of the produced artifacts with [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier).
+
+
+This aims to ensure the users that the artifacts are coming from containerssh.
+
+An example of verification :
+```sh
+slsa-verifier verify-artifact <artifact-to-verify> \
+--provenance-path <path-to-your-provenance> \
+--source-uri github.com/containerssh/containerssh
+```
+
+If the verification is successful, the process should produce the following output :
+```
+Verifying artifact <artifact-to-verify>: PASSED
+PASSED: Verified SLSA provenance
+```
+
+
 ## Contributing
 
 If you would like to contribute, please check out our [Code of Conduct](https://github.com/ContainerSSH/community/blob/main/CODE_OF_CONDUCT.md) as well as our [contribution documentation](https://containerssh.io/development/).


### PR DESCRIPTION
## Changes introduced with this PR

The work introduced via this pull request focuses on modifying the build workflow `main.yml` to generate a signed provenance (according to SLSA) for all the artifacts of a release. A special section has been added to the README to explain the verification process.

To explain briefly the changes, a new artifact (`multiple.intoto.jsonl`) is produced during release time. This document is a signed provenance for every artifact which can be verified according to the README section (Verify provenance).

There is also modifications in both `main.yml` and `nightly.yml` to add some comments and also to switch from version tags to hashes when calling external actions.

SLSA is a framework that focuses on the security of the supply chain. It has been mentionned in the  [following issue](https://github.com/ContainerSSH/ContainerSSH/issues/575#issue-1933497933). You can refer to [this documentation](https://slsa.dev/) for more information about the framework.

All the following should allow ContainerSSH to be compliant with SLSA build level 3 : 
- Provenance exists and is distributed (through the build platform)
- Provenance is signed
- Provenance is unforgeable

Signing keys are handled via SLSA provenance generator through [Sigstore](https://www.sigstore.dev/). If you want more information feel free to contact us.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).