### PR TITLE
Add CLOMonitor exemption for trademark disclaimer

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,6 @@
+# CLOMonitor metadata file
+# https://github.com/cncf/clomonitor/blob/main/docs/metadata/.clomonitor.yml
+
+exemptions:
+  - check: trademark_disclaimer
+    reason: "The website root is a (js/html) redirect to the current version which contains the disclaimer. CLOMonitor doesn't follow redirects."


### PR DESCRIPTION
## Changes introduced with this PR

Currently the website uses a javascript/html tag based redirect from the root to the current version which CLOMonitor cannot follow. Add an exemption to this check to mark that we are actually compliant.

See https://github.com/ContainerSSH/containerssh.github.io/issues/53 for more context.

I'll merge in a week unless someone stops me for a review/comments.

Closes https://github.com/ContainerSSH/containerssh.github.io/issues/53

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).