### PR TITLE
Add automatic SBOM generation on CycloneDX format 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,10 @@ jobs:
           echo "${GPG_KEY}" | base64 -d | gpg --batch --import && echo "${GPG_KEY}" | base64 -d >/tmp/signing.gpg
         env:
           GPG_KEY: "${{ secrets.GPG_KEY }}"
+      - name: Generate SBOM
+        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0
+        with:
+          version: v1
       - name: Run GoReleaser (release)
         id: goreleaser-task
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 #v5.0.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,6 +90,13 @@ signs:
 source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{ .Version }}-source'
+sboms:
+  - id: sbom-config
+    documents : 
+      - "containerssh.cdx.sbom"  
+    cmd : cyclonedx-gomod
+    args: [ "mod", "-licenses", "-json", "-output", "$document", "../"]
+    artifacts: source 
 dist: build
 release:
   github:


### PR DESCRIPTION
## Changes introduced with this PR
---

The work introduced via this pull request focuses on modifying the build process on the `main.yml` and `goreleaser.yml` files to automatically generate a Software Bill of Materials as suggested on [this](https://github.com/ContainerSSH/ContainerSSH/issues/575#issue-1933497933) issue.

A new artifact `containerssh.cdx.sbom` is created at each release. The artifact's checksum is stored in the checksum file, so it can be verified considering the checksum file is signed. Thanks to this, the SBOM file will also be included in the provenance generation process.

We decided to use the OWASP CycloneDX SBOM standard, approved by the NTIA as you can see in their [report](https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf). It is a relatively new, fully automated, security-focused lightweight SBOM standard which provides many tools such as the SBOM generator for Go modules, as well as Github [actions](https://github.com/CycloneDX/gh-gomod-generate-sbom) for a smooth integration into the existing workflow. 

If you have any question, feel free to contact us.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).