### PR TITLE
fix: x11 forward crash

### DIFF
--- a/internal/sshserver/serverImpl.go
+++ b/internal/sshserver/serverImpl.go
@@ -1316,6 +1316,7 @@ func (s *serverImpl) onX11(connectionID string, requestID uint64, sessionChannel
 
 	reverseForwardHandler := ReverseForwardHandler{
 		sshConn: conn.sshConn,
+		server:  s,
 		logger:  s.logger,
 	}
 	err := sessionChannel.OnX11Request(requestID, x11.SingleConnection, x11.Protocol, x11.Cookie, x11.Screen, &reverseForwardHandler)


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0xd8 pc=0x1b98ce0] goroutine 47 [running]:
go.containerssh.io/containerssh/internal/sshserver.(*ReverseForwardHandler).openChannel(0xc0008a0360, {0x22796da, 0x3}, {0xc0004b8f40, 0x11, 0x40})
        /home/runner/work/ContainerSSH/ContainerSSH/internal/sshserver/reverseForwardHandlerImpl.go:57 +0x40
go.containerssh.io/containerssh/internal/sshserver.(*ReverseForwardHandler).NewChannelX11(0xc0008a0360, {0xc000709630?, 0x0?}, 0x0?)
        /home/runner/work/ContainerSSH/ContainerSSH/internal/sshserver/reverseForwardHandlerImpl.go:50 +0x8a
go.containerssh.io/containerssh/internal/agentforward.(*agentForward).serveX11(0xc0008c6580, 0xc00074c620, {0x26b2ac0, 0xc0008a0360})
        /home/runner/work/ContainerSSH/ContainerSSH/internal/agentforward/agentForwardImpl.go:81 +0x189
created by go.containerssh.io/containerssh/internal/agentforward.(*agentForward).setupX11 in goroutine 70
        /home/runner/work/ContainerSSH/ContainerSSH/internal/agentforward/agentForwardImpl.go:171 +0x246

## Changes introduced with this PR

Please explain your changes here.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).