### PR TITLE
fix nil pointer dereference bug by initializing the *sync.Mutex.

### DIFF
--- a/internal/auditlog/storage/s3/queue.go
+++ b/internal/auditlog/storage/s3/queue.go
@@ -329,6 +329,7 @@ func (q *uploadQueue) recover(name string) error {
 
 	// Create a new upload
 	entry := &queueEntry{
+		lock:          &sync.Mutex{},
 		logger:        q.logger,
 		name:          name,
 		file:          file,


### PR DESCRIPTION
## Changes introduced with this PR

fixes panic I got when using the s3 audit logs when there were local audit logs to be pushed to s3 and recover() is called.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xdcb0aa]
goroutine 35 [running]:
internal/sync.(*Mutex).Lock(...)
        /opt/hostedtoolcache/go/1.25.8/x64/src/internal/sync/mutex.go:63
sync.(*Mutex).Lock(...)
        /opt/hostedtoolcache/go/1.25.8/x64/src/sync/mutex.go:46
go.containerssh.io/containerssh/internal/auditlog/storage/s3.(*uploadQueue).uploadLoop(0xc000673a00, 0xc000128a60, {0xc00077d21c, 0x20}, 0xc000926140)
        /home/runner/work/ContainerSSH/ContainerSSH/internal/auditlog/storage/s3/upload.go:234 +0x40a
created by go.containerssh.io/containerssh/internal/auditlog/storage/s3.(*uploadQueue).upload in goroutine 1
        /home/runner/work/ContainerSSH/ContainerSSH/internal/auditlog/storage
```

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).