### PR TITLE
fix(config): reject Docker network config that decodes to no endpoints

### DIFF
--- a/config/docker.go
+++ b/config/docker.go
@@ -430,5 +430,13 @@ func (l *DockerLaunchConfig) Validate() error {
 	if l.ContainerConfig.Image == "" {
 		return wrap(newError("image", "no image name provided"), "container")
 	}
+	if l.NetworkConfig != nil && len(l.NetworkConfig.EndpointsConfig) == 0 {
+		return newError(
+			"network",
+			"network configuration was provided but contains no endpoints, "+
+				"specify at least one entry under \"endpointsConfig\" (e.g. network.endpointsConfig.<networkName>.networkId), "+
+				"or remove the \"network\" key entirely to use the default network",
+		)
+	}
 	return nil
 }

--- a/config/docker_launch_config_test.go
+++ b/config/docker_launch_config_test.go
@@ -1,0 +1,43 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"go.containerssh.io/containerssh/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDockerLaunchConfigValidateNetworkWithoutEndpoints(t *testing.T) {
+	cfgText := "container:\n  image: \"containerssh/containerssh-guest-image\"\nnetwork:\n  name: \"administrator_default\"\n"
+	cfg := config.DockerLaunchConfig{}
+	assert.NoError(t, yaml.Unmarshal([]byte(cfgText), &cfg))
+
+	err := cfg.Validate()
+	assert.Error(
+		t,
+		err,
+		"a network block that decodes to no endpoints (e.g. from a misspelled field such as \"name\" "+
+			"instead of \"endpointsConfig\") should be rejected instead of silently falling back to the default network",
+	)
+}
+
+func TestDockerLaunchConfigValidateNetworkWithEndpoints(t *testing.T) {
+	cfgText := "container:\n  image: \"containerssh/containerssh-guest-image\"\n" +
+		"network:\n  endpointsconfig:\n    administrator_default:\n      networkid: \"abc123\"\n"
+	cfg := config.DockerLaunchConfig{}
+	assert.NoError(t, yaml.Unmarshal([]byte(cfgText), &cfg))
+
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestDockerLaunchConfigValidateNoNetwork(t *testing.T) {
+	cfg := config.DockerLaunchConfig{
+		ContainerConfig: &container.Config{
+			Image: "containerssh/containerssh-guest-image",
+		},
+	}
+
+	assert.NoError(t, cfg.Validate())
+}


### PR DESCRIPTION
Motivation:
A user reported that a container was created in the default "bridge"
network even though they configured docker.execution.network to attach
it to a different network. The root cause is that network.NetworkingConfig
(github.com/docker/docker/api/types/network) has a single field,
EndpointsConfig, with no yaml/json tag, so the correct key is
"endpointsConfig" with per-network entries. Their config used a field
that does not exist on that struct. Because DockerLaunchConfig's
UnmarshalYAML/UnmarshalJSON deliberately decode leniently (unknown
fields are dropped, to tolerate Docker API fields being removed across
versions), the unknown field is silently ignored and NetworkConfig ends
up as a non-nil pointer with an empty EndpointsConfig map. This empty
config is passed straight to ContainerCreate, and Docker's daemon
attaches the container to the default bridge network with no error
surfaced anywhere.

Approach:
Add a validation check in DockerLaunchConfig.Validate() that rejects a
network config which is present but decodes to zero endpoints. No
legitimate use case sets "network:" to a value with zero endpoints and
expects it to succeed as anything other than "no network config" (which
is already expressed by omitting the key, leaving the pointer nil and
skipping the new check). This does not touch the intentionally lenient
YAML/JSON decoding, so forward-compatibility with removed Docker API
fields is preserved; it only adds a fail-fast semantic check after
parsing, turning a silent misconfiguration into a clear error at config
load time instead of a silent runtime fallback to the wrong network.

Validation:
- go build ./...  (passes)
- go test ./config/...  (passes, including the 3 new tests)
- Confirmed the new test is a real regression test: with the fix
  reverted (git stash -- config/docker.go) the new test
  TestDockerLaunchConfigValidateNetworkWithoutEndpoints fails
  ("An error is expected but got nil"); with the fix restored it
  passes.
- go vet ./config/...  (clean)
- golangci-lint run ./config/...  (same pre-existing staticcheck
  issues in unrelated files as before this change; none on the added
  lines)
- Not run: no Docker-daemon-backed integration test was exercised;
  this fix is pure config-validation logic with no daemon interaction,
  so no live reproduction against dockerd was needed or attempted.

Impact:
This does not change behavior for a correctly specified network config,
nor for configs that omit the network key entirely (the default). It
only turns a previously silent misconfiguration, which already produced
a broken/unintended result (the container landing on the wrong
network), into a clear config-load-time validation error.

Report: https://github.com/ContainerSSH/ContainerSSH/issues/639
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #639