### PR TITLE
feat: make the keyboard-interactive login banner configurable

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -3,9 +3,11 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path"
+	"text/template"
 	"time"
 )
 
@@ -456,6 +458,16 @@ type AuthOAuth2ClientConfig struct {
 	// questions.
 	DeviceFlowClients []string `json:"deviceFlowClients" yaml:"deviceFlowClients"`
 
+	// DeviceFlowPrompt is the message shown to the connecting user when the device authorization flow is used. It
+	// is evaluated as a Go text/template with the {{.AuthorizationURL}} and {{.UserCode}} variables available (see
+	// OAuth2DeviceFlowPromptData). If left empty, DefaultDeviceFlowPrompt is used.
+	DeviceFlowPrompt string `json:"deviceFlowPrompt" yaml:"deviceFlowPrompt"`
+
+	// AuthorizationCodeFlowPrompt is the message shown to the connecting user when the authorization code flow is
+	// used. It is evaluated as a Go text/template with the {{.AuthorizationURL}} variable available (see
+	// OAuth2AuthorizationCodeFlowPromptData). If left empty, DefaultAuthorizationCodeFlowPrompt is used.
+	AuthorizationCodeFlowPrompt string `json:"authorizationCodeFlowPrompt" yaml:"authorizationCodeFlowPrompt"`
+
 	// AuthTimeout is the timeout for the overall authentication call. If the server
 	// responds with a non-200 response the call will be retried until this timeout is reached.
 	AuthTimeout time.Duration `json:"authTimeout" yaml:"authTimeout" default:"120s"`
@@ -493,7 +505,48 @@ func (o *AuthOAuth2ClientConfig) Validate() error {
 		}
 	}
 
+	if err := validateOAuth2Prompt(o.DeviceFlowPrompt, OAuth2DeviceFlowPromptData{}); err != nil {
+		return wrap(err, "deviceFlowPrompt")
+	}
+	if err := validateOAuth2Prompt(o.AuthorizationCodeFlowPrompt, OAuth2AuthorizationCodeFlowPromptData{}); err != nil {
+		return wrap(err, "authorizationCodeFlowPrompt")
+	}
+
 	return nil
+}
+
+const (
+	// DefaultDeviceFlowPrompt is the default message template shown to the user during the device authorization
+	// flow when AuthOAuth2ClientConfig.DeviceFlowPrompt is not set.
+	DefaultDeviceFlowPrompt = "Please click the following link: {{.AuthorizationURL}}\n\nEnter the following code: {{.UserCode}}\n"
+	// DefaultAuthorizationCodeFlowPrompt is the default message template shown to the user during the
+	// authorization code flow when AuthOAuth2ClientConfig.AuthorizationCodeFlowPrompt is not set.
+	DefaultAuthorizationCodeFlowPrompt = "Please click the following link to log in: {{.AuthorizationURL}}\n\n"
+)
+
+// OAuth2DeviceFlowPromptData is the data available in the DeviceFlowPrompt template.
+type OAuth2DeviceFlowPromptData struct {
+	// AuthorizationURL is the URL the user needs to open to authorize the connection.
+	AuthorizationURL string
+	// UserCode is the code the user needs to enter on the authorization page.
+	UserCode string
+}
+
+// OAuth2AuthorizationCodeFlowPromptData is the data available in the AuthorizationCodeFlowPrompt template.
+type OAuth2AuthorizationCodeFlowPromptData struct {
+	// AuthorizationURL is the URL the user needs to open to log in.
+	AuthorizationURL string
+}
+
+func validateOAuth2Prompt(prompt string, data interface{}) error {
+	if prompt == "" {
+		return nil
+	}
+	tpl, err := template.New("prompt").Parse(prompt)
+	if err != nil {
+		return err
+	}
+	return tpl.Execute(io.Discard, data)
 }
 
 // OAuth2ProviderName provides the various methods of oAuth2 authentication.

--- a/config/auth_oauth2_prompt_internal_test.go
+++ b/config/auth_oauth2_prompt_internal_test.go
@@ -1,0 +1,67 @@
+package config
+
+import "testing"
+
+func TestValidateOAuth2PromptEmptyIsValid(t *testing.T) {
+	if err := validateOAuth2Prompt("", OAuth2DeviceFlowPromptData{}); err != nil {
+		t.Fatalf("expected an empty prompt to be valid, got: %v", err)
+	}
+}
+
+func TestValidateOAuth2PromptDefaultsAreValid(t *testing.T) {
+	if err := validateOAuth2Prompt(DefaultDeviceFlowPrompt, OAuth2DeviceFlowPromptData{}); err != nil {
+		t.Fatalf("expected the default device flow prompt to be valid, got: %v", err)
+	}
+	if err := validateOAuth2Prompt(
+		DefaultAuthorizationCodeFlowPrompt,
+		OAuth2AuthorizationCodeFlowPromptData{},
+	); err != nil {
+		t.Fatalf("expected the default authorization code flow prompt to be valid, got: %v", err)
+	}
+}
+
+func TestValidateOAuth2PromptRejectsBrokenTemplates(t *testing.T) {
+	if err := validateOAuth2Prompt("{{.UserCode", OAuth2DeviceFlowPromptData{}); err == nil {
+		t.Fatal("expected an error for an unterminated template, got none")
+	}
+	if err := validateOAuth2Prompt("{{.NoSuchField}}", OAuth2DeviceFlowPromptData{}); err == nil {
+		t.Fatal("expected an error for an unknown template variable, got none")
+	}
+}
+
+func newTestAuthOAuth2ClientConfig() AuthOAuth2ClientConfig {
+	return AuthOAuth2ClientConfig{
+		Redirect: OAuth2RedirectConfig{
+			HTTPServerConfiguration: HTTPServerConfiguration{
+				Listen: "127.0.0.1:8080",
+			},
+		},
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		Provider:     AuthOAuth2GitHubProvider,
+		GitHub: AuthGitHubConfig{
+			URL: "https://github.com",
+		},
+	}
+}
+
+func TestAuthOAuth2ClientConfigValidatePrompts(t *testing.T) {
+	cfg := newTestAuthOAuth2ClientConfig()
+	cfg.DeviceFlowPrompt = "Open {{.AuthorizationURL}} and confirm {{.UserCode}}."
+	cfg.AuthorizationCodeFlowPrompt = "Log in: {{.AuthorizationURL}}"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid prompts to pass validation, got: %v", err)
+	}
+
+	cfg = newTestAuthOAuth2ClientConfig()
+	cfg.DeviceFlowPrompt = "{{.UserCode"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected an error for an invalid deviceFlowPrompt, got none")
+	}
+
+	cfg = newTestAuthOAuth2ClientConfig()
+	cfg.AuthorizationCodeFlowPrompt = "{{.NoSuchField}}"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected an error for an invalid authorizationCodeFlowPrompt, got none")
+	}
+}

--- a/config/ssh.go
+++ b/config/ssh.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"text/template"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -33,6 +34,12 @@ type SSHConfig struct {
 	MACs SSHMACList `json:"macs" yaml:"macs" default:"[\"hmac-sha2-256-etm@openssh.com\",\"hmac-sha2-256\"]" comment:"SSHMAC algorithms to use"`
 	// Banner is the banner sent to the client on connecting.
 	Banner string `json:"banner" yaml:"banner" comment:"Host banner to show after the username" default:""`
+	// KeyboardInteractiveName is the name field sent to the client with keyboard-interactive authentication
+	// requests (RFC 4256, SSH_MSG_USERAUTH_INFO_REQUEST). Clients such as OpenSSH display it as a separate line
+	// above the instruction text of each challenge. It is evaluated as a Go text/template with the {{.Username}}
+	// variable available (see SSHKeyboardInteractiveNameData). It defaults to "{{.Username}}", matching the
+	// behavior of previous ContainerSSH versions. Set it to an empty string to send no name at all.
+	KeyboardInteractiveName *string `json:"keyboardInteractiveName" yaml:"keyboardInteractiveName" comment:"Name field sent with keyboard-interactive authentication requests" default:"{{.Username}}"`
 	// HostKeys are the host keys either in PEM format, or filenames to load.
 	HostKeys []string `json:"hostkeys" yaml:"hostkeys" comment:"Host keys in PEM format or files to load PEM host keys from."`
 	// ClientAliveInterval is the duration between keep alive messages that
@@ -120,7 +127,33 @@ func (cfg SSHConfig) Validate() error {
 	if cfg.ClientAliveCountMax <= 0 {
 		return newError("clientAliveCountMax", "clientAliveCountMax should be at least 1")
 	}
+	if cfg.KeyboardInteractiveName != nil {
+		if err := validateKeyboardInteractiveName(*cfg.KeyboardInteractiveName); err != nil {
+			return wrap(err, "keyboardInteractiveName")
+		}
+	}
 	return nil
+}
+
+// SSHKeyboardInteractiveNameData is the data available in the KeyboardInteractiveName template.
+type SSHKeyboardInteractiveNameData struct {
+	// Username is the username the client is authenticating as.
+	Username string
+}
+
+// DefaultKeyboardInteractiveName is the default value for KeyboardInteractiveName, matching the behavior of
+// previous ContainerSSH versions.
+const DefaultKeyboardInteractiveName = "{{.Username}}"
+
+func validateKeyboardInteractiveName(name string) error {
+	if name == "" {
+		return nil
+	}
+	tpl, err := template.New("keyboardInteractiveName").Parse(name)
+	if err != nil {
+		return err
+	}
+	return tpl.Execute(io.Discard, SSHKeyboardInteractiveNameData{})
 }
 
 type stringer interface {

--- a/config/ssh_kbi_name_internal_test.go
+++ b/config/ssh_kbi_name_internal_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+func TestValidateKeyboardInteractiveNameEmptyIsValid(t *testing.T) {
+	if err := validateKeyboardInteractiveName(""); err != nil {
+		t.Fatalf("expected an empty keyboardInteractiveName to be valid, got: %v", err)
+	}
+}
+
+func TestValidateKeyboardInteractiveNameTemplates(t *testing.T) {
+	if err := validateKeyboardInteractiveName("{{.Username}}"); err != nil {
+		t.Fatalf("expected the username template to be valid, got: %v", err)
+	}
+	if err := validateKeyboardInteractiveName("Example Corp SSH login"); err != nil {
+		t.Fatalf("expected a static name to be valid, got: %v", err)
+	}
+	if err := validateKeyboardInteractiveName("{{.Username"); err == nil {
+		t.Fatal("expected an error for an unterminated template, got none")
+	}
+	if err := validateKeyboardInteractiveName("{{.NoSuchField}}"); err == nil {
+		t.Fatal("expected an error for an unknown template variable, got none")
+	}
+}
+
+func newTestSSHConfigForKbiName() SSHConfig {
+	return SSHConfig{
+		ServerVersion:       "SSH-2.0-ContainerSSH",
+		Ciphers:             SSHCipherList{"aes256-ctr"},
+		KexAlgorithms:       SSHKexList{"curve25519-sha256@libssh.org"},
+		MACs:                SSHMACList{"hmac-sha2-256"},
+		ClientAliveCountMax: 3,
+	}
+}
+
+func TestSSHConfigValidateKeyboardInteractiveName(t *testing.T) {
+	cfg := newTestSSHConfigForKbiName()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected an unset keyboardInteractiveName to be valid, got: %v", err)
+	}
+
+	name := "{{.Username}}"
+	cfg.KeyboardInteractiveName = &name
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected the username template to be valid, got: %v", err)
+	}
+
+	broken := "{{.Username"
+	cfg.KeyboardInteractiveName = &broken
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected an error for an unterminated template, got none")
+	}
+}

--- a/internal/auth/oauth2_factory.go
+++ b/internal/auth/oauth2_factory.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io"
 	goHttp "net/http"
+	textTemplate "text/template"
 
 	"go.containerssh.io/containerssh/config"
 	"go.containerssh.io/containerssh/http"
@@ -125,8 +126,38 @@ func NewOAuth2Client(cfg config.AuthOAuth2ClientConfig, logger log.Logger, colle
 		)
 	}
 
+	deviceFlowPrompt, err := parseOAuth2Prompt(
+		"deviceFlowPrompt",
+		cfg.DeviceFlowPrompt,
+		config.DefaultDeviceFlowPrompt,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	authorizationCodeFlowPrompt, err := parseOAuth2Prompt(
+		"authorizationCodeFlowPrompt",
+		cfg.AuthorizationCodeFlowPrompt,
+		config.DefaultAuthorizationCodeFlowPrompt,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &oauth2Client{
-		logger:   logger,
-		provider: provider,
+		logger:                      logger,
+		provider:                    provider,
+		deviceFlowPrompt:            deviceFlowPrompt,
+		authorizationCodeFlowPrompt: authorizationCodeFlowPrompt,
 	}, redirectServer, nil
+}
+
+func parseOAuth2Prompt(name string, promptTemplate string, defaultTemplate string) (*textTemplate.Template, error) {
+	if promptTemplate == "" {
+		promptTemplate = defaultTemplate
+	}
+	tpl, err := textTemplate.New(name).Parse(promptTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the oAuth2 %s template (%w)", name, err)
+	}
+	return tpl, nil
 }

--- a/internal/auth/oauth2_factory_internal_test.go
+++ b/internal/auth/oauth2_factory_internal_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"go.containerssh.io/containerssh/config"
+	"go.containerssh.io/containerssh/internal/structutils"
+	"go.containerssh.io/containerssh/log"
+)
+
+func newTestOAuth2ClientConfig() config.AuthOAuth2ClientConfig {
+	cfg := config.AuthOAuth2ClientConfig{}
+	structutils.Defaults(&cfg)
+	cfg.ClientID = "test-client"
+	cfg.ClientSecret = "test-secret"
+	cfg.Provider = config.AuthOAuth2GitHubProvider
+	return cfg
+}
+
+func TestNewOAuth2ClientDefaultPrompts(t *testing.T) {
+	cfg := newTestOAuth2ClientConfig()
+
+	client, redirectServer, err := NewOAuth2Client(cfg, log.NewTestLogger(t), nil)
+	if err != nil {
+		t.Fatalf("failed to create the oAuth2 client (%v)", err)
+	}
+	if redirectServer == nil {
+		t.Fatal("expected a redirect server")
+	}
+	oauth2client, ok := client.(*oauth2Client)
+	if !ok {
+		t.Fatalf("unexpected client type: %T", client)
+	}
+	prompt, err := renderOAuth2Prompt(oauth2client.deviceFlowPrompt, config.OAuth2DeviceFlowPromptData{
+		AuthorizationURL: "https://example.com/device",
+		UserCode:         "ABCD-EFGH",
+	})
+	if err != nil {
+		t.Fatalf("failed to render the default device flow prompt (%v)", err)
+	}
+	if !strings.HasPrefix(prompt, "Please click the following link: https://example.com/device") {
+		t.Fatalf("unexpected default device flow prompt: %q", prompt)
+	}
+}
+
+func TestNewOAuth2ClientCustomPrompts(t *testing.T) {
+	cfg := newTestOAuth2ClientConfig()
+	cfg.DeviceFlowPrompt = "Open {{.AuthorizationURL}} and confirm {{.UserCode}}."
+	cfg.AuthorizationCodeFlowPrompt = "Log in: {{.AuthorizationURL}}"
+
+	client, _, err := NewOAuth2Client(cfg, log.NewTestLogger(t), nil)
+	if err != nil {
+		t.Fatalf("failed to create the oAuth2 client (%v)", err)
+	}
+	oauth2client := client.(*oauth2Client)
+	prompt, err := renderOAuth2Prompt(oauth2client.deviceFlowPrompt, config.OAuth2DeviceFlowPromptData{
+		AuthorizationURL: "https://example.com/device",
+		UserCode:         "ABCD-EFGH",
+	})
+	if err != nil {
+		t.Fatalf("failed to render the custom device flow prompt (%v)", err)
+	}
+	if prompt != "Open https://example.com/device and confirm ABCD-EFGH." {
+		t.Fatalf("unexpected custom device flow prompt: %q", prompt)
+	}
+	prompt, err = renderOAuth2Prompt(oauth2client.authorizationCodeFlowPrompt, config.OAuth2AuthorizationCodeFlowPromptData{
+		AuthorizationURL: "https://example.com/login",
+	})
+	if err != nil {
+		t.Fatalf("failed to render the custom authorization code flow prompt (%v)", err)
+	}
+	if prompt != "Log in: https://example.com/login" {
+		t.Fatalf("unexpected custom authorization code flow prompt: %q", prompt)
+	}
+}
+
+func TestNewOAuth2ClientRejectsInvalidPrompt(t *testing.T) {
+	cfg := newTestOAuth2ClientConfig()
+	cfg.DeviceFlowPrompt = "{{.UserCode"
+
+	if _, _, err := NewOAuth2Client(cfg, log.NewTestLogger(t), nil); err == nil {
+		t.Fatal("expected an error for an invalid device flow prompt, got none")
+	}
+}

--- a/internal/auth/oauth2_impl.go
+++ b/internal/auth/oauth2_impl.go
@@ -2,18 +2,35 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"strings"
+	"text/template"
 	"time"
 
+	"go.containerssh.io/containerssh/config"
 	"go.containerssh.io/containerssh/log"
 	"go.containerssh.io/containerssh/message"
 	"go.containerssh.io/containerssh/metadata"
 )
 
 type oauth2Client struct {
-	provider OAuth2Provider
-	logger   log.Logger
+	provider                    OAuth2Provider
+	logger                      log.Logger
+	deviceFlowPrompt            *template.Template
+	authorizationCodeFlowPrompt *template.Template
+}
+
+func renderOAuth2Prompt(tpl *template.Template, data interface{}) (string, error) {
+	prompt := &strings.Builder{}
+	if err := tpl.Execute(prompt, data); err != nil {
+		return "", message.WrapUser(
+			err,
+			message.EAuthConfigError,
+			"Authentication failed.",
+			"Failed to render the oAuth2 %s template.",
+			tpl.Name(),
+		)
+	}
+	return prompt.String(), nil
 }
 
 type oauth2Context struct {
@@ -61,12 +78,18 @@ func (o *oauth2Client) KeyboardInteractive(
 		if err == nil {
 			authorizationURL, userCode, expiration, err := deviceFlow.GetAuthorizationURL(ctx)
 			if err == nil {
+				prompt, promptErr := renderOAuth2Prompt(
+					o.deviceFlowPrompt,
+					config.OAuth2DeviceFlowPromptData{
+						AuthorizationURL: authorizationURL,
+						UserCode:         userCode,
+					},
+				)
+				if promptErr != nil {
+					return &oauth2Context{false, meta.AuthFailed(), promptErr, deviceFlow}
+				}
 				_, err = challenge(
-					fmt.Sprintf(
-						"Please click the following link: %s\n\nEnter the following code: %s\n",
-						authorizationURL,
-						userCode,
-					),
+					prompt,
 					KeyboardInteractiveQuestions{},
 				)
 				if err != nil {
@@ -90,11 +113,17 @@ func (o *oauth2Client) KeyboardInteractive(
 		if err == nil {
 			link, err := authCodeFlow.GetAuthorizationURL(ctx)
 			if err == nil {
+				prompt, promptErr := renderOAuth2Prompt(
+					o.authorizationCodeFlowPrompt,
+					config.OAuth2AuthorizationCodeFlowPromptData{
+						AuthorizationURL: link,
+					},
+				)
+				if promptErr != nil {
+					return &oauth2Context{false, meta.AuthFailed(), promptErr, authCodeFlow}
+				}
 				answers, err := challenge(
-					fmt.Sprintf(
-						"Please click the following link to log in: %s\n\n",
-						link,
-					),
+					prompt,
 					KeyboardInteractiveQuestions{
 						KeyboardInteractiveQuestion{
 							ID:           "code",

--- a/internal/auth/oauth2_impl_internal_test.go
+++ b/internal/auth/oauth2_impl_internal_test.go
@@ -1,0 +1,251 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.containerssh.io/containerssh/config"
+	"go.containerssh.io/containerssh/log"
+	"go.containerssh.io/containerssh/metadata"
+)
+
+type fakeDeviceFlow struct {
+	meta         metadata.ConnectionAuthPendingMetadata
+	deauthorized bool
+}
+
+func (f *fakeDeviceFlow) Deauthorize(_ context.Context) {
+	f.deauthorized = true
+}
+
+func (f *fakeDeviceFlow) GetAuthorizationURL(_ context.Context) (string, string, time.Duration, error) {
+	return "https://example.com/device", "ABCD-EFGH", time.Minute, nil
+}
+
+func (f *fakeDeviceFlow) Verify(_ context.Context) (string, metadata.ConnectionAuthenticatedMetadata, error) {
+	return "access-token", f.meta.Authenticated(f.meta.Username), nil
+}
+
+type fakeAuthCodeFlow struct {
+	meta          metadata.ConnectionAuthPendingMetadata
+	deauthorized  bool
+	receivedState string
+	receivedCode  string
+}
+
+func (f *fakeAuthCodeFlow) Deauthorize(_ context.Context) {
+	f.deauthorized = true
+}
+
+func (f *fakeAuthCodeFlow) GetAuthorizationURL(_ context.Context) (string, error) {
+	return "https://example.com/login", nil
+}
+
+func (f *fakeAuthCodeFlow) Verify(_ context.Context, state string, code string) (
+	string,
+	metadata.ConnectionAuthenticatedMetadata,
+	error,
+) {
+	f.receivedState = state
+	f.receivedCode = code
+	return "access-token", f.meta.Authenticated(f.meta.Username), nil
+}
+
+type fakeOAuth2Provider struct {
+	deviceFlow   OAuth2DeviceFlow
+	authCodeFlow OAuth2AuthorizationCodeFlow
+}
+
+func (f *fakeOAuth2Provider) SupportsDeviceFlow() bool {
+	return f.deviceFlow != nil
+}
+
+func (f *fakeOAuth2Provider) GetDeviceFlow(_ context.Context, _ metadata.ConnectionAuthPendingMetadata) (
+	OAuth2DeviceFlow,
+	error,
+) {
+	return f.deviceFlow, nil
+}
+
+func (f *fakeOAuth2Provider) SupportsAuthorizationCodeFlow() bool {
+	return f.authCodeFlow != nil
+}
+
+func (f *fakeOAuth2Provider) GetAuthorizationCodeFlow(_ context.Context, _ metadata.ConnectionAuthPendingMetadata) (
+	OAuth2AuthorizationCodeFlow,
+	error,
+) {
+	return f.authCodeFlow, nil
+}
+
+func newTestOAuth2Client(
+	t *testing.T,
+	provider OAuth2Provider,
+	deviceFlowPrompt string,
+	authorizationCodeFlowPrompt string,
+) *oauth2Client {
+	deviceTpl, err := parseOAuth2Prompt("deviceFlowPrompt", deviceFlowPrompt, config.DefaultDeviceFlowPrompt)
+	if err != nil {
+		t.Fatalf("failed to parse the device flow prompt (%v)", err)
+	}
+	authCodeTpl, err := parseOAuth2Prompt(
+		"authorizationCodeFlowPrompt",
+		authorizationCodeFlowPrompt,
+		config.DefaultAuthorizationCodeFlowPrompt,
+	)
+	if err != nil {
+		t.Fatalf("failed to parse the authorization code flow prompt (%v)", err)
+	}
+	return &oauth2Client{
+		provider:                    provider,
+		logger:                      log.NewTestLogger(t),
+		deviceFlowPrompt:            deviceTpl,
+		authorizationCodeFlowPrompt: authCodeTpl,
+	}
+}
+
+func testAuthPendingMetadata() metadata.ConnectionAuthPendingMetadata {
+	return metadata.NewTestMetadata().StartAuthentication("SSH-2.0-test", "foo")
+}
+
+func TestOAuth2KeyboardInteractiveDeviceFlowDefaultPrompt(t *testing.T) {
+	meta := testAuthPendingMetadata()
+	flow := &fakeDeviceFlow{meta: meta}
+	client := newTestOAuth2Client(t, &fakeOAuth2Provider{deviceFlow: flow}, "", "")
+
+	var instruction string
+	ctx := client.KeyboardInteractive(
+		meta,
+		func(i string, questions KeyboardInteractiveQuestions) (KeyboardInteractiveAnswers, error) {
+			instruction = i
+			if len(questions) != 0 {
+				t.Fatalf("expected no questions for the device flow, got %d", len(questions))
+			}
+			return KeyboardInteractiveAnswers{}, nil
+		},
+	)
+	if !ctx.Success() {
+		t.Fatalf("expected a successful device flow authentication, got: %v", ctx.Error())
+	}
+	expected := "Please click the following link: https://example.com/device\n\nEnter the following code: ABCD-EFGH\n"
+	if instruction != expected {
+		t.Fatalf("unexpected device flow instruction: %q", instruction)
+	}
+	if ctx.Metadata().Username != "foo" {
+		t.Fatalf("unexpected authenticated username: %q", ctx.Metadata().Username)
+	}
+}
+
+func TestOAuth2KeyboardInteractiveDeviceFlowCustomPrompt(t *testing.T) {
+	meta := testAuthPendingMetadata()
+	flow := &fakeDeviceFlow{meta: meta}
+	client := newTestOAuth2Client(
+		t,
+		&fakeOAuth2Provider{deviceFlow: flow},
+		"Sign in at {{.AuthorizationURL}} with code {{.UserCode}}.",
+		"",
+	)
+
+	var instruction string
+	ctx := client.KeyboardInteractive(
+		meta,
+		func(i string, _ KeyboardInteractiveQuestions) (KeyboardInteractiveAnswers, error) {
+			instruction = i
+			return KeyboardInteractiveAnswers{}, nil
+		},
+	)
+	if !ctx.Success() {
+		t.Fatalf("expected a successful device flow authentication, got: %v", ctx.Error())
+	}
+	expected := "Sign in at https://example.com/device with code ABCD-EFGH."
+	if instruction != expected {
+		t.Fatalf("unexpected device flow instruction: %q", instruction)
+	}
+}
+
+func TestOAuth2KeyboardInteractiveDeviceFlowPromptRenderFailure(t *testing.T) {
+	meta := testAuthPendingMetadata()
+	flow := &fakeDeviceFlow{meta: meta}
+	// Parses fine, fails at render time on the real user code.
+	client := newTestOAuth2Client(t, &fakeOAuth2Provider{deviceFlow: flow}, "{{index .UserCode 999}}", "")
+
+	ctx := client.KeyboardInteractive(
+		meta,
+		func(_ string, _ KeyboardInteractiveQuestions) (KeyboardInteractiveAnswers, error) {
+			t.Fatal("the challenge must not be sent if the prompt cannot be rendered")
+			return KeyboardInteractiveAnswers{}, nil
+		},
+	)
+	if ctx.Success() {
+		t.Fatal("expected the authentication to fail when the prompt cannot be rendered")
+	}
+	if ctx.Error() == nil {
+		t.Fatal("expected an error when the prompt cannot be rendered")
+	}
+}
+
+func TestOAuth2KeyboardInteractiveDeviceFlowChallengeError(t *testing.T) {
+	meta := testAuthPendingMetadata()
+	flow := &fakeDeviceFlow{meta: meta}
+	client := newTestOAuth2Client(t, &fakeOAuth2Provider{deviceFlow: flow}, "", "")
+
+	ctx := client.KeyboardInteractive(
+		meta,
+		func(_ string, _ KeyboardInteractiveQuestions) (KeyboardInteractiveAnswers, error) {
+			return KeyboardInteractiveAnswers{}, errors.New("client disconnected")
+		},
+	)
+	if ctx.Success() {
+		t.Fatal("expected the authentication to fail when the challenge errors")
+	}
+}
+
+func TestOAuth2KeyboardInteractiveAuthorizationCodeFlow(t *testing.T) {
+	meta := testAuthPendingMetadata()
+	flow := &fakeAuthCodeFlow{meta: meta}
+	client := newTestOAuth2Client(t, &fakeOAuth2Provider{authCodeFlow: flow}, "", "")
+
+	var instruction string
+	ctx := client.KeyboardInteractive(
+		meta,
+		func(i string, questions KeyboardInteractiveQuestions) (KeyboardInteractiveAnswers, error) {
+			instruction = i
+			if len(questions) != 1 {
+				t.Fatalf("expected one question for the authorization code flow, got %d", len(questions))
+			}
+			return KeyboardInteractiveAnswers{
+				Answers: map[string]string{"code": "the-state|the-code"},
+			}, nil
+		},
+	)
+	if !ctx.Success() {
+		t.Fatalf("expected a successful authorization code flow authentication, got: %v", ctx.Error())
+	}
+	expected := "Please click the following link to log in: https://example.com/login\n\n"
+	if instruction != expected {
+		t.Fatalf("unexpected authorization code flow instruction: %q", instruction)
+	}
+	if flow.receivedState != "the-state" || flow.receivedCode != "the-code" {
+		t.Fatalf("unexpected state/code: %q/%q", flow.receivedState, flow.receivedCode)
+	}
+}
+
+func TestOAuth2KeyboardInteractiveAuthorizationCodeFlowInvalidCode(t *testing.T) {
+	meta := testAuthPendingMetadata()
+	flow := &fakeAuthCodeFlow{meta: meta}
+	client := newTestOAuth2Client(t, &fakeOAuth2Provider{authCodeFlow: flow}, "", "")
+
+	ctx := client.KeyboardInteractive(
+		meta,
+		func(_ string, _ KeyboardInteractiveQuestions) (KeyboardInteractiveAnswers, error) {
+			return KeyboardInteractiveAnswers{
+				Answers: map[string]string{"code": "missing-separator"},
+			}, nil
+		},
+	)
+	if ctx.Success() {
+		t.Fatal("expected the authentication to fail for a code without state")
+	}
+}

--- a/internal/auth/oauth2_prompt_internal_test.go
+++ b/internal/auth/oauth2_prompt_internal_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"testing"
+
+	"go.containerssh.io/containerssh/config"
+)
+
+func TestRenderOAuth2PromptDefaultDeviceFlow(t *testing.T) {
+	tpl, err := parseOAuth2Prompt("deviceFlowPrompt", "", config.DefaultDeviceFlowPrompt)
+	if err != nil {
+		t.Fatalf("failed to parse the default device flow prompt (%v)", err)
+	}
+	prompt, err := renderOAuth2Prompt(tpl, config.OAuth2DeviceFlowPromptData{
+		AuthorizationURL: "https://example.com/device",
+		UserCode:         "ABCD-EFGH",
+	})
+	if err != nil {
+		t.Fatalf("failed to render the default device flow prompt (%v)", err)
+	}
+	expected := "Please click the following link: https://example.com/device\n\nEnter the following code: ABCD-EFGH\n"
+	if prompt != expected {
+		t.Fatalf("unexpected device flow prompt: %q", prompt)
+	}
+}
+
+func TestRenderOAuth2PromptDefaultAuthorizationCodeFlow(t *testing.T) {
+	tpl, err := parseOAuth2Prompt("authorizationCodeFlowPrompt", "", config.DefaultAuthorizationCodeFlowPrompt)
+	if err != nil {
+		t.Fatalf("failed to parse the default authorization code flow prompt (%v)", err)
+	}
+	prompt, err := renderOAuth2Prompt(tpl, config.OAuth2AuthorizationCodeFlowPromptData{
+		AuthorizationURL: "https://example.com/login",
+	})
+	if err != nil {
+		t.Fatalf("failed to render the default authorization code flow prompt (%v)", err)
+	}
+	expected := "Please click the following link to log in: https://example.com/login\n\n"
+	if prompt != expected {
+		t.Fatalf("unexpected authorization code flow prompt: %q", prompt)
+	}
+}
+
+func TestRenderOAuth2PromptCustomTemplate(t *testing.T) {
+	tpl, err := parseOAuth2Prompt(
+		"deviceFlowPrompt",
+		"Welcome to example.org!\n\nOpen {{.AuthorizationURL}} and confirm code {{.UserCode}}.\n",
+		config.DefaultDeviceFlowPrompt,
+	)
+	if err != nil {
+		t.Fatalf("failed to parse the custom device flow prompt (%v)", err)
+	}
+	prompt, err := renderOAuth2Prompt(tpl, config.OAuth2DeviceFlowPromptData{
+		AuthorizationURL: "https://example.org/device",
+		UserCode:         "WXYZ-1234",
+	})
+	if err != nil {
+		t.Fatalf("failed to render the custom device flow prompt (%v)", err)
+	}
+	expected := "Welcome to example.org!\n\nOpen https://example.org/device and confirm code WXYZ-1234.\n"
+	if prompt != expected {
+		t.Fatalf("unexpected custom device flow prompt: %q", prompt)
+	}
+}
+
+func TestParseOAuth2PromptInvalidTemplate(t *testing.T) {
+	if _, err := parseOAuth2Prompt("deviceFlowPrompt", "{{.UserCode", config.DefaultDeviceFlowPrompt); err == nil {
+		t.Fatal("expected an error for an unterminated template, got none")
+	}
+}

--- a/internal/sshserver/New.go
+++ b/internal/sshserver/New.go
@@ -1,10 +1,12 @@
 package sshserver
 
 import (
+	"fmt"
 	"sync"
+	"text/template"
 
-    "go.containerssh.io/containerssh/config"
-    "go.containerssh.io/containerssh/log"
+	"go.containerssh.io/containerssh/config"
+	"go.containerssh.io/containerssh/log"
 )
 
 // New creates a new SSH server ready to be run. It may return an error if the configuration is invalid.
@@ -16,14 +18,26 @@ func New(cfg config.SSHConfig, handler Handler, logger log.Logger) (Server, erro
 	if err != nil {
 		return nil, err
 	}
+	kbiName := config.DefaultKeyboardInteractiveName
+	if cfg.KeyboardInteractiveName != nil {
+		kbiName = *cfg.KeyboardInteractiveName
+	}
+	var kbiNameTemplate *template.Template
+	if kbiName != "" {
+		kbiNameTemplate, err = template.New("keyboardInteractiveName").Parse(kbiName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the keyboardInteractiveName template (%w)", err)
+		}
+	}
 	return &serverImpl{
-		cfg:          cfg,
-		handler:      handler,
-		logger:       logger,
-		wg:           &sync.WaitGroup{},
-		lock:         &sync.Mutex{},
-		listenSocket: nil,
-		hostKeys:     hostKeys,
+		cfg:             cfg,
+		handler:         handler,
+		logger:          logger,
+		kbiNameTemplate: kbiNameTemplate,
+		wg:              &sync.WaitGroup{},
+		lock:            &sync.Mutex{},
+		listenSocket:    nil,
+		hostKeys:        hostKeys,
 		shutdownHandlers: &shutdownRegistry{
 			lock:      &sync.Mutex{},
 			callbacks: map[string]shutdownHandler{},

--- a/internal/sshserver/kbi_name_internal_test.go
+++ b/internal/sshserver/kbi_name_internal_test.go
@@ -1,0 +1,86 @@
+package sshserver
+
+import (
+	"testing"
+	"text/template"
+
+	"go.containerssh.io/containerssh/config"
+	"go.containerssh.io/containerssh/internal/structutils"
+	"go.containerssh.io/containerssh/log"
+)
+
+func TestRenderKeyboardInteractiveNameUnset(t *testing.T) {
+	server := &serverImpl{}
+	name, err := server.renderKeyboardInteractiveName("foo")
+	if err != nil {
+		t.Fatalf("expected no error for an unset template, got: %v", err)
+	}
+	if name != "" {
+		t.Fatalf("expected an empty name for an unset template, got: %q", name)
+	}
+}
+
+func TestRenderKeyboardInteractiveNameUsername(t *testing.T) {
+	server := &serverImpl{
+		kbiNameTemplate: template.Must(template.New("keyboardInteractiveName").Parse("{{.Username}}")),
+	}
+	name, err := server.renderKeyboardInteractiveName("foo")
+	if err != nil {
+		t.Fatalf("expected no error for the username template, got: %v", err)
+	}
+	if name != "foo" {
+		t.Fatalf("expected the username as name, got: %q", name)
+	}
+}
+
+func TestRenderKeyboardInteractiveNameStatic(t *testing.T) {
+	server := &serverImpl{
+		kbiNameTemplate: template.Must(template.New("keyboardInteractiveName").Parse("Example Corp SSH login")),
+	}
+	name, err := server.renderKeyboardInteractiveName("foo")
+	if err != nil {
+		t.Fatalf("expected no error for a static name, got: %v", err)
+	}
+	if name != "Example Corp SSH login" {
+		t.Fatalf("expected the static name, got: %q", name)
+	}
+}
+
+func TestNewParsesKeyboardInteractiveName(t *testing.T) {
+	cfg := config.SSHConfig{}
+	structutils.Defaults(&cfg)
+	if err := cfg.GenerateHostKey(); err != nil {
+		t.Fatalf("failed to generate a host key (%v)", err)
+	}
+
+	// Default: the previous behavior, sending the username.
+	srv, err := New(cfg, nil, log.NewTestLogger(t))
+	if err != nil {
+		t.Fatalf("failed to create the SSH server (%v)", err)
+	}
+	name, err := srv.(*serverImpl).renderKeyboardInteractiveName("foo")
+	if err != nil {
+		t.Fatalf("failed to render the default keyboard-interactive name (%v)", err)
+	}
+	if name != "foo" {
+		t.Fatalf("expected the username as the default name, got: %q", name)
+	}
+
+	// Empty string: no name is sent.
+	empty := ""
+	cfg.KeyboardInteractiveName = &empty
+	srv, err = New(cfg, nil, log.NewTestLogger(t))
+	if err != nil {
+		t.Fatalf("failed to create the SSH server (%v)", err)
+	}
+	if srv.(*serverImpl).kbiNameTemplate != nil {
+		t.Fatal("expected no name template for an empty keyboardInteractiveName")
+	}
+
+	// Invalid template: rejected by the configuration validation.
+	broken := "{{.Username"
+	cfg.KeyboardInteractiveName = &broken
+	if _, err := New(cfg, nil, log.NewTestLogger(t)); err == nil {
+		t.Fatal("expected an error for an unterminated keyboardInteractiveName template, got none")
+	}
+}

--- a/internal/sshserver/serverImpl.go
+++ b/internal/sshserver/serverImpl.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	protocol "go.containerssh.io/containerssh/agentprotocol"
@@ -39,6 +40,7 @@ type serverImpl struct {
 	nextGlobalRequestID uint64
 	nextChannelID       uint64
 	hostKeys            []ssh.Signer
+	kbiNameTemplate     *template.Template
 	shutdownHandlers    *shutdownRegistry
 	shuttingDown        bool
 }
@@ -304,8 +306,13 @@ func (s *serverImpl) createKeyboardInteractiveHandler(
 				echos = append(echos, question.EchoResponse)
 			}
 
-			// user, instruction string, questions []string, echos []bool
-			answerList, err := challenge(conn.User(), instruction, q, echos)
+			name, err := s.renderKeyboardInteractiveName(conn.User())
+			if err != nil {
+				return answers, err
+			}
+
+			// name, instruction string, questions []string, echos []bool
+			answerList, err := challenge(name, instruction, q, echos)
 			for index, rawAnswer := range answerList {
 				question := questions[index]
 				answers.answers[question.getID()] = rawAnswer
@@ -330,6 +337,26 @@ func (s *serverImpl) createKeyboardInteractiveHandler(
 		}
 		return nil, authenticatedMetadata, fmt.Errorf("authentication currently unavailable")
 	}
+}
+
+// renderKeyboardInteractiveName renders the configured KeyboardInteractiveName template for the given username. If
+// no template is configured it returns an empty string, meaning no name is sent to the client.
+func (s *serverImpl) renderKeyboardInteractiveName(username string) (string, error) {
+	if s.kbiNameTemplate == nil {
+		return "", nil
+	}
+	name := &strings.Builder{}
+	if err := s.kbiNameTemplate.Execute(name, config.SSHKeyboardInteractiveNameData{
+		Username: username,
+	}); err != nil {
+		return "", messageCodes.WrapUser(
+			err,
+			messageCodes.EAuthConfigError,
+			"Authentication failed.",
+			"Failed to render the keyboardInteractiveName template.",
+		)
+	}
+	return name.String(), nil
 }
 
 func (s *serverImpl) createConfiguration(


### PR DESCRIPTION
## Changes introduced with this PR

The banner a user sees during keyboard-interactive oAuth2 authentication was hardcoded in two places:

1. The SSH server always sent the username in the name field of SSH_MSG_USERAUTH_INFO_REQUEST (RFC 4256). Clients such as OpenSSH print it as a stray extra line above the instruction text, although RFC 4256 intends this field as a title for the authentication process and the client already knows the username.
2. The oAuth2 prompt texts ("Please click the following link: ...") were hardcoded fmt.Sprintf strings, so installations could not brand, shorten, or localize them.

This makes both configurable via Go text/template settings:

- auth.oauth2.deviceFlowPrompt with {{.AuthorizationURL}} and {{.UserCode}}, defaulting to the previous hardcoded message
- auth.oauth2.authorizationCodeFlowPrompt with {{.AuthorizationURL}}, defaulting to the previous hardcoded message
- ssh.keyboardInteractiveName with {{.Username}}, defaulting to "{{.Username}}" (the previous behavior); set it to an empty string to send no name at all

Example:

    ssh:
      keyboardInteractiveName: ""
    auth:
      keyboardInteractive:
        method: oauth2
        oauth2:
          deviceFlowPrompt: |
            Welcome to the example.com bastion!

            Sign in at {{.AuthorizationURL}}
            and approve this SSH session.

Before:

    $ ssh bastion.example.com
    alice
    Please click the following link: https://auth.example.com/device?user_code=ABCD-EFGH

    Enter the following code: ABCD-EFGH

After:

    $ ssh bastion.example.com
    Welcome to the example.com bastion!

    Sign in at https://auth.example.com/device?user_code=ABCD-EFGH
    and approve this SSH session.

Templates are validated during configuration validation and parsed once at construction time. A template that fails to render at runtime fails the authentication closed. The defaults keep the on-wire behavior of previous versions unchanged.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).