### PR TITLE
feat(oidc): support non-string token claims

### DIFF
--- a/internal/auth/oauth2_oidc_flow.go
+++ b/internal/auth/oauth2_oidc_flow.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -151,10 +152,15 @@ func (o *oidcFlow) getIdentity(
 				m["OIDC_TOKEN"] = metadata.Value{Value: token, Sensitive: true}
 				for field, value := range resp {
 					valueString, ok := value.(string)
-					if ok {
-						m["OIDC_USERINFO_"+strings.ToUpper(field)] = metadata.Value{
-							Value: valueString,
+					if !ok {
+						encodedValue, marshalErr := json.Marshal(value)
+						if marshalErr != nil {
+							continue
 						}
+						valueString = string(encodedValue)
+					}
+					m["OIDC_USERINFO_"+strings.ToUpper(field)] = metadata.Value{
+						Value: valueString,
 					}
 				}
 				return token, meta.Authenticated(usernameString), nil


### PR DESCRIPTION
## Changes introduced with this PR

Support non-string token claims by marshaling to JSON. This allows us to accept claims like the standard `groups` claim, which was previously discarded due to being an array rather than a string.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).